### PR TITLE
Remove unneeded builder functions in seq module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,3 @@ documentation = "https://docs.rs/rsgenetic/"
 
 [dependencies]
 rand = "^0.5.4"
-rayon = "1.0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,7 +178,6 @@
         unused_qualifications)]
 
 extern crate rand;
-extern crate rayon;
 
 /// Contains the definition of a Phenotype.
 pub mod pheno;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,9 +173,17 @@
 //!
 //! See the `examples` directory in the repository for more elaborate examples.
 
-#![deny(missing_docs, missing_debug_implementations, missing_copy_implementations, trivial_casts,
-        trivial_numeric_casts, unsafe_code, unstable_features, unused_import_braces,
-        unused_qualifications)]
+#![deny(
+    missing_docs,
+    missing_debug_implementations,
+    missing_copy_implementations,
+    trivial_casts,
+    trivial_numeric_casts,
+    unsafe_code,
+    unstable_features,
+    unused_import_braces,
+    unused_qualifications
+)]
 
 extern crate rand;
 

--- a/src/sim/mod.rs
+++ b/src/sim/mod.rs
@@ -17,11 +17,11 @@
 use pheno::{Fitness, Phenotype};
 use stats::StatsCollector;
 
-pub mod seq;
-pub mod select;
-pub mod types;
-mod iterlimit;
 mod earlystopper;
+mod iterlimit;
+pub mod select;
+pub mod seq;
+pub mod types;
 
 /// A `Builder` can create new instances of an object.
 /// For this library, only `Simulation` objects use this `Builder`.
@@ -86,9 +86,11 @@ where
     /// Be careful to check for failures when running `step()` in a loop,
     /// to avoid infinite loops. To run the simulation until convergence or until
     /// reaching a maximum number of iterations, consider using `run()` instead:
-    #[deprecated(note="To encourage checking the `StepResult` while maintaining backwards \
-                 compatibility, this function has been deprecated in favour of `checked_step`.",
-                 since="1.7.0")]
+    #[deprecated(
+        note = "To encourage checking the `StepResult` while maintaining backwards \
+                compatibility, this function has been deprecated in favour of `checked_step`.",
+        since = "1.7.0"
+    )]
     fn step(&mut self) -> StepResult;
     /// Make one step in the simulation. This function returns a `StepResult`:
     ///

--- a/src/sim/mod.rs
+++ b/src/sim/mod.rs
@@ -16,8 +16,6 @@
 
 use pheno::{Fitness, Phenotype};
 use stats::StatsCollector;
-use std::cell::RefCell;
-use std::rc::Rc;
 
 pub mod seq;
 pub mod select;
@@ -69,15 +67,6 @@ where
 {
     /// A `Builder` is used to create instances of a `Simulation`.
     type B: Builder<Self>;
-
-
-    /// Create a `Builder` to create an instance.
-    ///
-    /// `population` is a required parameter of any `Simulation`, which
-    /// is why it is a parameter of this function.
-    fn builder_with_stats(population: &'a mut Vec<T>, sc: Option<Rc<RefCell<S>>>) -> Self::B
-    where
-        Self: Sized;
 
     /// Create a `Builder` to create an instance.
     ///

--- a/src/sim/select/max.rs
+++ b/src/sim/select/max.rs
@@ -16,14 +16,16 @@
 
 #![allow(deprecated)]
 
-use pheno::{Fitness, Phenotype};
 use super::*;
+use pheno::{Fitness, Phenotype};
 
 /// Selects best performing phenotypes from the population.
 #[derive(Clone, Copy, Debug)]
-#[deprecated(note="The `MaximizeSelector` has bad performance due to sorting. For better performance with potentially different results, \
+#[deprecated(
+    note = "The `MaximizeSelector` has bad performance due to sorting. For better performance with potentially different results, \
                    use the `UnstableMaximizeSelector`.",
-                 since="1.7.7")]
+    since = "1.7.7"
+)]
 pub struct MaximizeSelector {
     count: usize,
 }
@@ -68,8 +70,8 @@ where
 
 #[cfg(test)]
 mod tests {
-    use sim::select::*;
     use pheno::*;
+    use sim::select::*;
     use test::Test;
 
     #[test]

--- a/src/sim/select/mod.rs
+++ b/src/sim/select/mod.rs
@@ -22,7 +22,6 @@
 //! number of selected parents.
 
 mod max;
-mod max_unstable;
 mod tournament;
 mod stochastic;
 
@@ -31,7 +30,6 @@ use std::fmt::Debug;
 
 #[allow(deprecated)]
 pub use self::max::MaximizeSelector;
-pub use self::max_unstable::UnstableMaximizeSelector;
 pub use self::tournament::TournamentSelector;
 pub use self::stochastic::StochasticSelector;
 

--- a/src/sim/select/mod.rs
+++ b/src/sim/select/mod.rs
@@ -22,16 +22,16 @@
 //! number of selected parents.
 
 mod max;
-mod tournament;
 mod stochastic;
+mod tournament;
 
 use pheno::{Fitness, Phenotype};
 use std::fmt::Debug;
 
 #[allow(deprecated)]
 pub use self::max::MaximizeSelector;
-pub use self::tournament::TournamentSelector;
 pub use self::stochastic::StochasticSelector;
+pub use self::tournament::TournamentSelector;
 
 /// `Parents` come in a `Vec` of two `T`'s.
 pub type Parents<T> = Vec<(T, T)>;

--- a/src/sim/select/stochastic.rs
+++ b/src/sim/select/stochastic.rs
@@ -14,8 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use pheno::{Fitness, Phenotype};
 use super::*;
+use pheno::{Fitness, Phenotype};
 use rand::Rng;
 
 /// Selects phenotypes at random, starting from a random index and taking equidistant jumps.

--- a/src/sim/select/tournament.rs
+++ b/src/sim/select/tournament.rs
@@ -14,8 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use pheno::{Fitness, Phenotype};
 use super::*;
+use pheno::{Fitness, Phenotype};
 use rand::Rng;
 
 /// Runs several tournaments, and selects best performing phenotypes from each tournament.
@@ -34,9 +34,11 @@ impl TournamentSelector {
     ///
     /// * `count`: must be larger than zero, a multiple of two and less than the population size.
     /// * `participants`: must be larger than one and less than the population size.
-    #[deprecated(note="The `TournamentSelector` requires at least 2 participants. This is not enforced
+    #[deprecated(
+        note = "The `TournamentSelector` requires at least 2 participants. This is not enforced
                        by the `new` function. You should use `new_checked` instead.",
-                 since="1.7.11")]
+        since = "1.7.11"
+    )]
     pub fn new(count: usize, participants: usize) -> TournamentSelector {
         TournamentSelector {
             count: count,

--- a/src/sim/seq.rs
+++ b/src/sim/seq.rs
@@ -20,29 +20,28 @@
 //! To use a `Simulator`, you need a `SimulatorBuilder`, which you can
 //! obtain by calling `Simulator::builder()`.
 
-use pheno::Phenotype;
 use pheno::Fitness;
+use pheno::Phenotype;
 use stats::StatsCollector;
 
+use super::earlystopper::*;
+use super::iterlimit::*;
+use super::select::*;
+use super::*;
+use rand::prng::XorShiftRng;
 use rand::Rng;
 use rand::SeedableRng;
-use rand::prng::XorShiftRng;
-use super::*;
-use super::select::*;
-use super::iterlimit::*;
-use super::earlystopper::*;
 use std::boxed::Box;
 use std::marker::PhantomData;
 
-use std::rc::Rc;
 use std::cell::RefCell;
+use std::rc::Rc;
 
-#[cfg(not(target_arch="wasm32"))]
+#[cfg(not(target_arch = "wasm32"))]
 type RandomGenerator = OsRng;
 
-#[cfg(target_arch="wasm32")]
+#[cfg(target_arch = "wasm32")]
 type RandomGenerator = XorShiftRng;
-
 
 /// A sequential implementation of `::sim::Simulation`.
 /// The genetic algorithm is run in a single thread.
@@ -63,8 +62,6 @@ where
     rng: Rc<RefCell<RandomGenerator>>,
 }
 
-
-
 impl<'a, T, F, S> Simulation<'a, T, F, S> for Simulator<'a, T, F, S>
 where
     T: Phenotype<F>,
@@ -72,9 +69,9 @@ where
     S: StatsCollector<F>,
 {
     type B = SimulatorBuilder<'a, T, F, S>;
-    
+
     #[allow(deprecated)]
-    #[cfg(not(target_arch="wasm32"))]
+    #[cfg(not(target_arch = "wasm32"))]
     fn builder(population: &'a mut Vec<T>) -> SimulatorBuilder<'a, T, F, S> {
         SimulatorBuilder {
             sim: Simulator {
@@ -91,9 +88,11 @@ where
     }
 
     #[allow(deprecated)]
-    #[cfg(target_arch="wasm32")]
+    #[cfg(target_arch = "wasm32")]
     fn builder(population: &'a mut Vec<T>) -> SimulatorBuilder<'a, T, F, S> {
-        let seed = [0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 1u8];
+        let seed = [
+            0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 1u8,
+        ];
         SimulatorBuilder {
             sim: Simulator {
                 population: population,
@@ -109,7 +108,6 @@ where
     }
 
     fn step(&mut self) -> StepResult {
-
         if self.population.is_empty() {
             self.error = Some(
                 "Tried to run a simulator without a population, or the \
@@ -130,7 +128,6 @@ where
         }
 
         if !should_stop {
-    
             let mut children: Vec<T>;
             {
                 // Perform selection
@@ -152,7 +149,8 @@ where
             self.population.append(&mut children);
 
             if let Some(ref mut stopper) = self.earlystopper {
-                let highest_fitness = self.population
+                let highest_fitness = self
+                    .population
                     .iter()
                     .max_by_key(|x| x.fitness())
                     .unwrap()
@@ -257,7 +255,7 @@ where
         self
     }
 
-        /// Set the maximum number of iterations of the resulting `Simulator`.
+    /// Set the maximum number of iterations of the resulting `Simulator`.
     ///
     /// The `Simulator` will stop running after this number of iterations.
     ///
@@ -277,7 +275,7 @@ where
         self
     }
 
-        /// Set the maximum number of iterations of the resulting `Simulator`.
+    /// Set the maximum number of iterations of the resulting `Simulator`.
     ///
     /// The `Simulator` will stop running after this number of iterations.
     ///
@@ -286,7 +284,6 @@ where
         self.sim.rng = rng;
         self
     }
-
 
     /// Set early stopping. If for `n_iters` iterations, the change in the highest fitness
     /// is smaller than `delta`, the simulator will stop running.
@@ -312,24 +309,23 @@ where
 #[cfg(test)]
 #[allow(deprecated)]
 mod tests {
-    use sim::*;
     use sim::select::*;
-    use test::Test;
-    use test::MyFitness;
+    use sim::*;
     use stats::NoStats;
-
+    use test::MyFitness;
+    use test::Test;
 
     #[test]
     fn test_kill_off_count() {
         let selector = MaximizeSelector::new(2);
         let mut population: Vec<Test> = (0..100).map(|i| Test { f: i }).collect();
-        let mut s: seq::Simulator<Test, MyFitness, NoStats> = seq::Simulator::builder(&mut population)
-            .set_selector(Box::new(selector))
+        let mut s: seq::Simulator<Test, MyFitness, NoStats> = seq::Simulator::builder(
+            &mut population,
+        ).set_selector(Box::new(selector))
             .build();
         s.kill_off(10);
         assert_eq!(s.population.len(), 90);
     }
-
 
     #[test]
     fn test_stats_collector() {

--- a/src/sim/seq.rs
+++ b/src/sim/seq.rs
@@ -29,10 +29,10 @@ use super::iterlimit::*;
 use super::select::*;
 use super::*;
 use rand::prng::XorShiftRng;
-use rand::Rng;
 use rand::SeedableRng;
 use std::boxed::Box;
 use std::marker::PhantomData;
+use rand::{OsRng, Rng};
 
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -81,7 +81,7 @@ where
                 earlystopper: None,
                 error: None,
                 phantom: PhantomData::default(),
-                stats: sc,
+                stats: None,
                 rng: Rc::new(RefCell::new(OsRng::new().unwrap())),
             },
         }

--- a/src/sim/seq.rs
+++ b/src/sim/seq.rs
@@ -24,9 +24,6 @@ use pheno::Phenotype;
 use pheno::Fitness;
 use stats::StatsCollector;
 
-use rand::prelude::*;
-use rand::rngs::*;
-use stats::NoStats;
 use rand::Rng;
 use rand::SeedableRng;
 use rand::prng::XorShiftRng;
@@ -78,7 +75,7 @@ where
     
     #[allow(deprecated)]
     #[cfg(not(target_arch="wasm32"))]
-    fn builder_with_stats(population: &'a mut Vec<T>, sc: Option<Rc<RefCell<S>>>) -> SimulatorBuilder<'a, T, F, S> {
+    fn builder(population: &'a mut Vec<T>) -> SimulatorBuilder<'a, T, F, S> {
         SimulatorBuilder {
             sim: Simulator {
                 population: population,
@@ -93,8 +90,9 @@ where
         }
     }
 
+    #[allow(deprecated)]
     #[cfg(target_arch="wasm32")]
-    fn builder_with_stats(population: &'a mut Vec<T>, sc: Option<Rc<RefCell<S>>>) -> SimulatorBuilder<'a, T, F, S> {
+    fn builder(population: &'a mut Vec<T>) -> SimulatorBuilder<'a, T, F, S> {
         let seed = [0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 1u8];
         SimulatorBuilder {
             sim: Simulator {
@@ -104,16 +102,10 @@ where
                 earlystopper: None,
                 error: None,
                 phantom: PhantomData::default(),
-                stats: sc,
+                stats: None,
                 rng: Rc::new(RefCell::new(XorShiftRng::from_seed(seed))),
             },
         }
-    }
-
-    /// Create builder.
-    #[allow(deprecated)]
-    fn builder(population: &'a mut Vec<T>) -> SimulatorBuilder<'a, T, F, S> {
-        Self::builder_with_stats(population, None)
     }
 
     fn step(&mut self) -> StepResult {
@@ -281,7 +273,6 @@ where
     ///
     /// Returns itself for chaining purposes.
     pub fn set_stats_collector(mut self, sc: Option<Rc<RefCell<S>>>) -> Self {
-
         self.sim.stats = sc;
         self
     }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -18,8 +18,7 @@ use pheno::Fitness;
 
 /// A collector for potential stats on the population's fitness or timing.
 ///
-pub trait StatsCollector<F: Fitness>
-{
+pub trait StatsCollector<F: Fitness> {
     ///Executed before a step, passing the current population's fitness
     ///
     fn before_step(&mut self, pop_fitness: &[F]) {}
@@ -30,7 +29,7 @@ pub trait StatsCollector<F: Fitness>
 }
 
 /// A NOOP implementation for common fitness types
-/// 
+///
 #[derive(Debug, Clone, Copy)]
 pub struct NoStats {}
 impl StatsCollector<i32> for NoStats {}

--- a/src/test.rs
+++ b/src/test.rs
@@ -18,9 +18,8 @@
 // several tests across the library.
 
 use pheno::*;
+use stats::{NoStats, StatsCollector};
 use std::cmp;
-use stats::{StatsCollector, NoStats};
-
 
 #[derive(Clone, Copy, Debug, PartialOrd, Ord, PartialEq, Eq)]
 pub struct MyFitness {
@@ -38,8 +37,6 @@ impl Fitness for MyFitness {
         }
     }
 }
-
-
 
 #[derive(Clone, Copy)]
 pub struct Test {


### PR DESCRIPTION
I took the liberty of cleaning up some code. Overall it looks quite good, if we can get a PoC working of `RsGenetic` running in the browser that would be cool.
